### PR TITLE
Expose num popped

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "orx-concurrent-queue"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "criterion",
  "orx-concurrent-bag",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ orx-fixed-vec = { version = "3.22.0", default-features = false }
 
 [dev-dependencies]
 criterion = { version = "0.7.0", default-features = false }
-orx-concurrent-bag = { version = "3.3.0" }
+orx-concurrent-bag = { version = "3.4.0" }
 rand_chacha = { version = "0.9.0" }
 rand = { version = "0.9.2" }
 test-case = { version = "3.3.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-queue"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2024"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A high performance and convenient thread safe queue that can concurrently grow and shrink with push, extend, pop and pull capabilities."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,13 @@ keywords = ["concurrency", "queue", "data-structures", "atomic", "lock-free"]
 categories = ["data-structures", "concurrency", "rust-patterns", "no-std"]
 
 [dependencies]
-orx-pinned-vec = { version = "3.20.0", default-features = false }
-orx-split-vec = { version = "3.21.0", default-features = false }
-orx-fixed-vec = { version = "3.21.0", default-features = false }
+orx-pinned-vec = { version = "3.21.0", default-features = false }
+orx-split-vec = { version = "3.22.0", default-features = false }
+orx-fixed-vec = { version = "3.22.0", default-features = false }
 
 [dev-dependencies]
 criterion = { version = "0.7.0", default-features = false }
-orx-concurrent-bag = { version = "3.2.0" }
+orx-concurrent-bag = { version = "3.3.0" }
 rand_chacha = { version = "0.9.0" }
 rand = { version = "0.9.2" }
 test-case = { version = "3.3.1" }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -688,6 +688,20 @@ where
 
     /// Returns the number of elements in the queue.
     ///
+    /// Importantly note that `len` is a shorthand for:
+    ///
+    /// ```ignore
+    /// let written = self.num_written(Ordering::Relaxed);
+    /// let popped = self.popped(Ordering::Relaxed);
+    /// written - popped
+    /// ```
+    ///
+    /// When a different ordering is required, you may write your own `len` method
+    /// using [`num_written`] and [`popped`] methods.
+    ///
+    /// [`num_written`]: ConcurrentQueue::num_written
+    /// [`popped`]: ConcurrentQueue::popped
+    ///
     /// # Examples
     ///
     /// ```

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -722,6 +722,7 @@ where
     /// _ = queue.pull(4);
     /// assert_eq!(queue.len(), 1);
     /// ```
+    #[inline(always)]
     pub fn len(&self) -> usize {
         self.written
             .load(Ordering::Relaxed)
@@ -774,6 +775,7 @@ where
     /// _ = queue.pop(); // None
     /// assert_eq!(queue.num_written(Ordering::Relaxed), 4);
     /// ```
+    #[inline(always)]
     pub fn num_written(&self, order: Ordering) -> usize {
         self.written.load(order)
     }
@@ -822,6 +824,7 @@ where
     /// _ = queue.pop(); // None
     /// assert_eq!(queue.num_write_reserved(Ordering::Relaxed), 4);
     /// ```
+    #[inline(always)]
     pub fn num_write_reserved(&self, order: Ordering) -> usize {
         self.write_reserved.load(order)
     }
@@ -854,6 +857,7 @@ where
     /// _ = queue.pop(); // None
     /// assert_eq!(queue.num_popped(Ordering::Relaxed), 4);
     /// ```
+    #[inline(always)]
     pub fn num_popped(&self, order: Ordering) -> usize {
         self.popped.load(order)
     }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -715,6 +715,49 @@ where
     }
 
     /// Returns the total number of positions reserved to be written.
+    ///
+    /// See [`num_written`] to get the number of elements which are
+    /// completely written.
+    ///
+    /// Note that in a synchronous program, number of reserved positions
+    /// will be equal to the number of written positions.
+    ///
+    /// In a concurrent program; however, it is possible to observe that
+    /// `num_write_reserved >= num_written` since we might observe the
+    /// counts while writing of some elements are in progress.
+    ///
+    /// However, we can never observe `num_write_reserved < num_written`.
+    ///
+    /// [`num_written`]: ConcurrentQueue::num_written
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_concurrent_queue::*;
+    /// use std::sync::atomic::Ordering;
+    ///
+    /// let queue = ConcurrentQueue::new();
+    ///
+    /// assert_eq!(queue.num_write_reserved(Ordering::Relaxed), 0);
+    ///
+    /// queue.push(1);
+    /// assert_eq!(queue.num_write_reserved(Ordering::Relaxed), 1);
+    ///
+    /// queue.extend([2, 3, 4]);
+    /// assert_eq!(queue.num_write_reserved(Ordering::Relaxed), 4);
+    ///
+    /// _ = queue.pop();
+    /// assert_eq!(queue.num_write_reserved(Ordering::Relaxed), 4);
+    ///
+    /// _ = queue.pull(2);
+    /// assert_eq!(queue.num_write_reserved(Ordering::Relaxed), 4);
+    ///
+    /// _ = queue.pull(10); // only 1 is pulled
+    /// assert_eq!(queue.num_write_reserved(Ordering::Relaxed), 4);
+    ///
+    /// _ = queue.pop(); // None
+    /// assert_eq!(queue.num_write_reserved(Ordering::Relaxed), 4);
+    /// ```
     pub fn num_write_reserved(&self, order: Ordering) -> usize {
         self.write_reserved.load(order)
     }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -719,6 +719,11 @@ where
         self.write_reserved.load(order)
     }
 
+    /// Returns the number of popped elements so far.
+    pub fn num_popped(&self, order: Ordering) -> usize {
+        self.popped.load(order)
+    }
+
     /// Returns true if the queue is empty, false otherwise.
     ///
     /// # Examples

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -720,6 +720,33 @@ where
     }
 
     /// Returns the number of popped elements so far.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_concurrent_queue::*;
+    /// use std::sync::atomic::Ordering;
+    ///
+    /// let queue = ConcurrentQueue::new();
+    ///
+    /// assert_eq!(queue.num_popped(Ordering::Relaxed), 0);
+    ///
+    /// queue.push(1);
+    /// queue.extend([2, 3, 4]);
+    /// assert_eq!(queue.num_popped(Ordering::Relaxed), 0);
+    ///
+    /// _ = queue.pop();
+    /// assert_eq!(queue.num_popped(Ordering::Relaxed), 1);
+    ///
+    /// _ = queue.pull(2);
+    /// assert_eq!(queue.num_popped(Ordering::Relaxed), 3);
+    ///
+    /// _ = queue.pull(10); // only 1 is pulled
+    /// assert_eq!(queue.num_popped(Ordering::Relaxed), 4);
+    ///
+    /// _ = queue.pop(); // None
+    /// assert_eq!(queue.num_popped(Ordering::Relaxed), 4);
+    /// ```
     pub fn num_popped(&self, order: Ordering) -> usize {
         self.popped.load(order)
     }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -692,15 +692,15 @@ where
     ///
     /// ```ignore
     /// let written = self.num_written(Ordering::Relaxed);
-    /// let popped = self.popped(Ordering::Relaxed);
+    /// let popped = self.num_popped(Ordering::Relaxed);
     /// written - popped
     /// ```
     ///
     /// When a different ordering is required, you may write your own `len` method
-    /// using [`num_written`] and [`popped`] methods.
+    /// using [`num_written`] and [`num_popped`] methods.
     ///
     /// [`num_written`]: ConcurrentQueue::num_written
-    /// [`popped`]: ConcurrentQueue::popped
+    /// [`num_popped`]: ConcurrentQueue::num_popped
     ///
     /// # Examples
     ///

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -714,6 +714,56 @@ where
             .saturating_sub(self.popped.load(Ordering::Relaxed))
     }
 
+    /// Returns the total number of positions written; i.e., total of
+    /// number of times we pushed and sum of lengths of iterators that
+    /// we extended the queue with.
+    ///
+    /// See [`num_write_reserved`] to get the number of positions which are
+    /// reserved to be written.
+    ///
+    /// Note that in a synchronous program, number of reserved positions
+    /// will be equal to the number of written positions.
+    ///
+    /// In a concurrent program; however, it is possible to observe that
+    /// `num_write_reserved >= num_written` since we might observe the
+    /// counts while writing of some elements are in progress.
+    ///
+    /// However, we can never observe `num_write_reserved < num_written`.
+    ///
+    /// [`num_written`]: ConcurrentQueue::num_written
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_concurrent_queue::*;
+    /// use std::sync::atomic::Ordering;
+    ///
+    /// let queue = ConcurrentQueue::new();
+    ///
+    /// assert_eq!(queue.num_written(Ordering::Relaxed), 0);
+    ///
+    /// queue.push(1);
+    /// assert_eq!(queue.num_written(Ordering::Relaxed), 1);
+    ///
+    /// queue.extend([2, 3, 4]);
+    /// assert_eq!(queue.num_written(Ordering::Relaxed), 4);
+    ///
+    /// _ = queue.pop();
+    /// assert_eq!(queue.num_written(Ordering::Relaxed), 4);
+    ///
+    /// _ = queue.pull(2);
+    /// assert_eq!(queue.num_written(Ordering::Relaxed), 4);
+    ///
+    /// _ = queue.pull(10); // only 1 is pulled
+    /// assert_eq!(queue.num_written(Ordering::Relaxed), 4);
+    ///
+    /// _ = queue.pop(); // None
+    /// assert_eq!(queue.num_written(Ordering::Relaxed), 4);
+    /// ```
+    pub fn num_written(&self, order: Ordering) -> usize {
+        self.written.load(order)
+    }
+
     /// Returns the total number of positions reserved to be written.
     ///
     /// See [`num_written`] to get the number of elements which are

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,5 +1,6 @@
 mod extend;
 mod into_inner;
+mod num_getters;
 mod pop;
 mod pull;
 mod pull_extend;

--- a/src/tests/num_getters.rs
+++ b/src/tests/num_getters.rs
@@ -12,6 +12,7 @@ fn num_getters() {
     // write
     for _ in 0..10 {
         assert_eq!(queue.num_write_reserved(order), wr);
+        assert_eq!(queue.num_written(order), wr);
         assert_eq!(queue.num_popped(order), p);
 
         queue.push('x');
@@ -21,6 +22,7 @@ fn num_getters() {
     // pop
     for _ in 0..6 {
         assert_eq!(queue.num_write_reserved(order), wr);
+        assert_eq!(queue.num_written(order), wr);
         assert_eq!(queue.num_popped(order), p);
 
         _ = queue.pop();
@@ -30,6 +32,7 @@ fn num_getters() {
     // write
     for _ in 4..20 {
         assert_eq!(queue.num_write_reserved(order), wr);
+        assert_eq!(queue.num_written(order), wr);
         assert_eq!(queue.num_popped(order), p);
 
         queue.push('x');
@@ -39,6 +42,7 @@ fn num_getters() {
     // pop
     for _ in 0..20 {
         assert_eq!(queue.num_write_reserved(order), wr);
+        assert_eq!(queue.num_written(order), wr);
         assert_eq!(queue.num_popped(order), p);
 
         _ = queue.pop();

--- a/src/tests/num_getters.rs
+++ b/src/tests/num_getters.rs
@@ -1,0 +1,51 @@
+use crate::ConcurrentQueue;
+use core::sync::atomic::Ordering;
+
+#[test]
+fn num_getters() {
+    let queue = ConcurrentQueue::new();
+    let order = Ordering::Relaxed;
+
+    let mut wr = 0;
+    let mut p = 0;
+
+    // write
+    for _ in 0..10 {
+        assert_eq!(queue.num_write_reserved(order), wr);
+        assert_eq!(queue.num_popped(order), p);
+
+        queue.push('x');
+        wr += 1;
+    }
+
+    // pop
+    for _ in 0..6 {
+        assert_eq!(queue.num_write_reserved(order), wr);
+        assert_eq!(queue.num_popped(order), p);
+
+        _ = queue.pop();
+        p += 1;
+    }
+
+    // write
+    for _ in 4..20 {
+        assert_eq!(queue.num_write_reserved(order), wr);
+        assert_eq!(queue.num_popped(order), p);
+
+        queue.push('x');
+        wr += 1;
+    }
+
+    // pop
+    for _ in 0..20 {
+        assert_eq!(queue.num_write_reserved(order), wr);
+        assert_eq!(queue.num_popped(order), p);
+
+        _ = queue.pop();
+        p += 1;
+    }
+
+    assert!(queue.is_empty());
+    assert_eq!(wr, 26);
+    assert_eq!(p, 26);
+}


### PR DESCRIPTION
`num_popped` and `num_written` methods are introduced which can be called with desired / required ordering.

Documentation of `len` is detailed, explaining that it is a shorthand for:

```rust
let written = self.num_written(Ordering::Relaxed);
let popped = self.num_popped(Ordering::Relaxed);
written - popped
```

using the relaxed ordering. However, the introduced methods allow the caller to compute length in a concurrent program with the desired ordering.


*Also*

Upgrades PinnedVec for improved safety guarantees: https://github.com/orxfun/orx-pinned-vec/releases/tag/3.21.0
